### PR TITLE
Implement toolbar with new document functionality and set caret

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Textarea</title>
 <style>
   * {
@@ -20,6 +20,26 @@
     }
   }
 
+  /* Small toolbar (no frameworks) */
+  .toolbar{
+    position: fixed;
+    top: 12px;
+    right: 12px;
+    z-index: 10;
+    display: flex;
+    gap: 8px;
+  }
+  .toolbar button{
+    font: 14px/1 system-ui;
+    padding: 8px 10px;
+    border-radius: 10px;
+    border: 1px solid color-mix(in oklab, currentColor 20%, transparent);
+    background: color-mix(in oklab, canvas 92%, currentColor 8%);
+    color: inherit;
+    cursor: pointer;
+  }
+  .toolbar button:active{ transform: translateY(1px); }
+
   article {
     outline: none;
     margin: 0 auto;
@@ -34,26 +54,57 @@
     text-wrap-style: pretty;
   }
 </style>
+
+<div class="toolbar">
+  <button id="newBtn" type="button" aria-label="Create a new document">New</button>
+</div>
+
 <article contenteditable="plaintext-only" spellcheck></article>
+
 <script>
   const article = document.querySelector('article')
-  article.addEventListener('input', debounce(500, save))
+  const newBtn = document.querySelector('#newBtn')
+
+  article.addEventListener('input', () => {
+    rememberCaret()
+    debouncedSave()
+  })
+
+  // Keep caret position up to date (mouse/keyboard selection changes)
+  document.addEventListener('selectionchange', debounce(150, rememberCaret))
+
   addEventListener('DOMContentLoaded', load)
   addEventListener('hashchange', load)
+
+  newBtn.addEventListener('click', () => newDocument())
+
+  // Document identity (stable per "New" document)
+  let currentDocId = ''
+
+  const debouncedSave = debounce(500, save)
 
   async function load() {
     try {
       if (location.hash === '') {
+        // Keep your existing "resume last" behavior,
+        // but now you can create a fresh doc via the New button.
         await set(localStorage.getItem('hash') ?? '')
         if (article.textContent) history.replaceState({}, '', await get())
+        focusEditor()
+        restoreCaret()
         return
       }
+
       await set(location.hash)
     } catch (e) {
       article.textContent = ''
       article.removeAttribute('style')
+      currentDocId = ''
     }
+
     updateTitle()
+    focusEditor()
+    restoreCaret()
   }
 
   async function save() {
@@ -61,23 +112,169 @@
     if (location.hash !== hash) history.replaceState({}, '', hash)
     try { localStorage.setItem('hash', hash) } catch (e) {}
     updateTitle()
+    // Ensure caret stays visible even after URL updates
+    focusEditor()
+    restoreCaret()
+  }
+
+  async function newDocument() {
+    // Generate a stable doc id that stays the same while the content-hash changes
+    currentDocId = makeDocId()
+
+    article.textContent = ''
+    article.removeAttribute('style')
+
+    // Create a real, unique URL immediately (even before typing)
+    const emptyData = await compress('')
+    const newHash = '#' + emptyData + ';' + currentDocId
+    history.pushState({}, '', newHash)
+
+    try { localStorage.setItem('hash', newHash) } catch (e) {}
+
+    updateTitle()
+    focusEditor()
+    setCaretOffset(article, 0)
+    rememberCaret()
   }
 
   async function set(hash) {
-    const [content, style] = (await decompress(hash.slice(1))).split('\x00')
+    // Accept '' or '#...'
+    const raw = (hash || '').startsWith('#') ? hash.slice(1) : hash
+    if (!raw) {
+      currentDocId = ''
+      article.textContent = ''
+      article.removeAttribute('style')
+      return
+    }
+
+    const { data, docid } = parseHash(raw)
+    currentDocId = docid || ''
+
+    const decompressed = await decompress(data)
+    const parts = decompressed.split('\x00')
+    const content = parts[0] ?? ''
+    const style = parts[1] ?? ''
+
     article.textContent = content
     if (style) article.setAttribute('style', style)
+    else article.removeAttribute('style')
   }
 
   async function get() {
     const style = article.getAttribute('style')
     const content = article.textContent + (style !== null ? '\x00' + style : '')
-    return '#' + await compress(content)
+
+    const data = await compress(content)
+    // Preserve stable doc id if present (new docs),
+    // otherwise keep the original behavior.
+    return '#' + data + (currentDocId ? ';' + currentDocId : '')
   }
 
   function updateTitle() {
     const match = article.textContent.match(/^\n*#(.+)\n/)
     document.title = match?.[1] ?? 'Textarea'
+  }
+
+  function parseHash(raw) {
+    // Format: <data>[;<docid>]
+    const i = raw.indexOf(';')
+    if (i === -1) return { data: raw, docid: '' }
+    return { data: raw.slice(0, i), docid: raw.slice(i + 1) }
+  }
+
+  function makeDocId() {
+    // Short, URL-safe, stable per document
+    return (crypto?.randomUUID?.() ?? (Date.now() + '-' + Math.random()))
+      .toString()
+      .replace(/[^a-z0-9]/gi, '')
+      .slice(0, 16)
+      .toLowerCase()
+  }
+
+  function focusEditor() {
+    try { article.focus({ preventScroll: true }) } catch (e) { article.focus() }
+  }
+
+  function caretStorageKey() {
+    // Prefer docid so caret survives content-hash changes while typing
+    if (currentDocId) return 'caret:' + currentDocId
+    // Legacy docs without docid: best-effort by current hash data
+    return 'caret:' + location.hash.slice(1)
+  }
+
+  function rememberCaret() {
+    const sel = getSelection()
+    if (!sel || sel.rangeCount === 0) return
+    if (document.activeElement !== article) return
+
+    const offset = getCaretOffset(article)
+    try { sessionStorage.setItem(caretStorageKey(), String(offset)) } catch (e) {}
+  }
+
+  function restoreCaret() {
+    let offset = 0
+    try {
+      const v = sessionStorage.getItem(caretStorageKey())
+      if (v != null) offset = Math.max(0, Number(v) || 0)
+    } catch (e) {}
+
+    setCaretOffset(article, offset)
+  }
+
+  function getCaretOffset(root) {
+    const sel = getSelection()
+    if (!sel || sel.rangeCount === 0) return 0
+    const range = sel.getRangeAt(0)
+    if (!root.contains(range.startContainer)) return 0
+
+    const pre = range.cloneRange()
+    pre.selectNodeContents(root)
+    pre.setEnd(range.startContainer, range.startOffset)
+    return pre.toString().length
+  }
+
+  function setCaretOffset(root, offset) {
+    focusEditor()
+
+    const selection = getSelection()
+    if (!selection) return
+
+    const range = document.createRange()
+    let remaining = offset
+
+    // Walk text nodes and place caret by character offset
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT)
+    let node = walker.nextNode()
+    let lastTextNode = null
+
+    while (node) {
+      lastTextNode = node
+      const len = node.nodeValue.length
+      if (remaining <= len) {
+        range.setStart(node, remaining)
+        range.collapse(true)
+        selection.removeAllRanges()
+        selection.addRange(range)
+        return
+      }
+      remaining -= len
+      node = walker.nextNode()
+    }
+
+    // If no text nodes (empty), place caret at start of element
+    if (!lastTextNode) {
+      range.setStart(root, 0)
+      range.collapse(true)
+      selection.removeAllRanges()
+      selection.addRange(range)
+      return
+    }
+
+    // If offset is beyond content length, place caret at end
+    range.setStart(lastTextNode, lastTextNode.nodeValue.length)
+    range.collapse(true)
+    selection.removeAllRanges()
+    selection.addRange(range)
   }
 
   async function compress(string) {


### PR DESCRIPTION
Added a toolbar with a 'New' button for document creation and updated event listeners to handle new document functionality. Otherwise when bookmarked the plain url to the index file you never can start a new document.
Also set the caret to make clear one can edit this