### PR TITLE
feat: observe for style changes and save to hash

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,15 +36,17 @@
 </style>
 <article contenteditable="plaintext-only" spellcheck></article>
 <script>
-  const article = document.querySelector('article')
-  article.addEventListener('input', debounce(500, save))
+  const debouncedSave = debounce(500, save)
 
-  const styleObserver = new MutationObserver(debounce(500, save))
-  styleObserver.observe(article, {attributes: true, attributeFilter: ['style']})
+  const article = document.querySelector('article')
+  article.addEventListener('input', debouncedSave)
 
   addEventListener('DOMContentLoaded', load)
   addEventListener('hashchange', load)
 
+  const styleObserver = new MutationObserver(debouncedSave)
+
+  let observerStarted = false;
   async function load() {
     try {
       if (location.hash !== '') await set(location.hash)
@@ -59,6 +61,11 @@
       article.focus()
     }
     updateTitle()
+
+    if (!observerStarted) {
+      observerStarted = true
+      styleObserver.observe(article, { attributes: true, attributeFilter: ['style'] })
+    }
   }
 
   async function save() {


### PR DESCRIPTION
Currently, changes to the style aren't detected and won't be written to the hash and localStorage unless the text is modified afterwards.

Add a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) on the `<article>` to observe for style changes and write them to the hash as well.

Edit:
- Moved the debounced `save` Function to a variable to reuse it in the MutationObserver.
- Start the MutationObserver after the initial load to prevent one unneccessary save due to the style change in the `set` function.