### PR TITLE
Fix: updateTitle regex to match headings without trailing newlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,8 +374,8 @@
   }
 
   function updateTitle() {
-    const match = article.textContent.match(/^\n*#(.+)\n/)
-    document.title = match?.[1] ?? 'Textarea'
+    const match = article.textContent.match(/^#\s*(.+)/m)
+    document.title = match?.[1]?.trim() ?? 'Textarea'
   }
 
   async function compress(string) {


### PR DESCRIPTION
Hii @antonmedv .
I had fixed the following code problem.  

**Problem:** 

The updateTitle() function uses a regex that requires a newline after the heading:
`/^\n*#(.+)\n/
`

This causes the page title to fail updating when:

- Heading is the last line in the document (no trailing newline)
- Multiple spaces appear after #
- Heading is not at the very start of the content

Example Case: 
```
User types "# Demo Title" at EOF
Expected: Browser tab shows "Demo Title"
Actual: Browser tab shows "Textarea" (fails silently)
```

**Solution**
Updated regex to:
`/^#\s*(.+)/m
`
With `.trim()` on captured text:

What This Fixes: 
- Headings at EOF (no trailing newline)
- Multiple spaces after # are normalized
- Multiline mode handles headings anywhere


**Test cases to verify:** 

**Before:** 

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/406a1956-8731-4546-9ffb-91c439087a1a" />

**After:**

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/7ce3270d-9da2-4177-a190-dbd9f1d26a75" />
 