### PR TITLE
Addition of fork reference / Feature improvements (Sidebar & short.io) in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A _minimalist_ text editor that lives entirely in your browser and stores everyt
 ## Related
 
 - [numbr.dev](https://numbr.dev) – my another website, same as textarea, only support calculations like `1 USD in EUR =`.
+- - [textarea.my fork](https://github.com/hk151109/textarea) – A fork by [Harikrishnan Gopal](https://github.com/hk151109) with a **Sidebar**, **Document History**, and **short.io integration** for managing url of large documents.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A _minimalist_ text editor that lives entirely in your browser and stores everyt
 ## Related
 
 - [numbr.dev](https://numbr.dev) – my another website, same as textarea, only support calculations like `1 USD in EUR =`.
-- - [textarea.my fork](https://github.com/hk151109/textarea) – A fork by [Harikrishnan Gopal](https://github.com/hk151109) with a **Sidebar**, **Document History**, and **short.io integration** for managing url of large documents.
+- [textarea.my fork](https://github.com/hk151109/textarea) – A fork by [Harikrishnan Gopal](https://github.com/hk151109) with a **Sidebar**, **Document History**, and **short.io integration** for managing url of large documents.
 
 ---
 


### PR DESCRIPTION
Hi,

I’ve been a fan of the minimalism of textarea.my and recently created a fork over at [hk151109/textarea](https://github.com/hk151109/textarea) that adds some utility for power users.

I'm opening this PR to add a link to this fork in the README. My version introduces several key features:

Sidebar & Document History: Users can now view and switch between their previous documents directly from a sidebar, making it easier to manage multiple notes.

short.io Integration: For documents with large content (where the URL hash becomes unwieldy), I've integrated short.io to generate clean, manageable short URLs.

Regarding a full PR for these features:
I haven't raised a PR for the code changes yet because I modified the deployment workflow for my own setup. However, if you're interested in merging these features, I’d be happy to revert the deployment logic to your original configuration and raise a clean PR for the Sidebar and short.io functionality.

Best,
Harikrishnan Gopal